### PR TITLE
Fix additional read after free issues related to registration

### DIFF
--- a/ext/nmatrix/nmatrix.h
+++ b/ext/nmatrix/nmatrix.h
@@ -389,7 +389,7 @@ extern "C" {
   void     nm_unregister_storage(nm::stype_t stype, const STORAGE* storage);
   void     nm_register_nmatrix(NMATRIX* nmatrix);
   void     nm_unregister_nmatrix(NMATRIX* nmatrix);
-
+  void	   nm_completely_unregister_value(VALUE& val);
 #ifdef __cplusplus
 }
 #endif

--- a/ext/nmatrix/storage/list/list.h
+++ b/ext/nmatrix/storage/list/list.h
@@ -81,7 +81,7 @@ extern "C" {
   void          nm_list_storage_unregister_list(const LIST* l, size_t recursions);
   void          nm_list_storage_register_node(const NODE* n);
   void          nm_list_storage_unregister_node(const NODE* n);
-
+  void		nm_list_storage_completely_unregister_node(const NODE* curr);
   ///////////////
   // Accessors //
   ///////////////

--- a/ext/nmatrix/util/sl_list.cpp
+++ b/ext/nmatrix/util/sl_list.cpp
@@ -31,6 +31,8 @@
 
 #include "sl_list.h"
 
+#include "storage/list/list.h"
+
 namespace nm { namespace list {
 
 /*
@@ -77,6 +79,7 @@ void del(LIST* list, size_t recursions) {
 
     if (recursions == 0) {
       //fprintf(stderr, "    free_val: %p\n", curr->val);
+      nm_list_storage_completely_unregister_node(curr);
       NM_FREE(curr->val);
       
     } else {
@@ -187,11 +190,12 @@ NODE* insert(LIST* list, bool replace, size_t key, void* val) {
   if (ins->key == key) {
     // key already exists
     if (replace) {
+      nm_list_storage_completely_unregister_node(ins);
       NM_FREE(ins->val);
       ins->val = val;
-      
+      nm_list_storage_register_node(ins);
     } else {
-    	NM_FREE(val);
+      NM_FREE(val);
     }
     
     return ins;


### PR DESCRIPTION
Two additional problems cropped up:
- Some of the list insert/replace methods can free a node while it's still
  registered.  Added a completely_unregister method to get rid of all
  instances of a VALUE in the registration stack.  Use with caution (probably
  only just before something is freed) as this can mess up the registration
  scheme if used improperly.
- Found an if/else mismatch in list slice_copy where the else was associated
  with the wrong if statement after introducing registration code.  Put the
  else back with the correct if by addition of braces.

This fixes all of the list-related valgrind problems for me.
