### PR TITLE
List regression

### DIFF
--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -1086,10 +1086,10 @@ static VALUE nm_init_new_version(int argc, VALUE* argv, VALUE self) {
       init = RARRAY_LEN(initial_ary) == 1 ? rubyobj_to_cval(rb_ary_entry(initial_ary, 0), dtype) : NULL;
     else
       init = rubyobj_to_cval(initial_ary, dtype);
-  }
-
-  if (dtype == nm::RUBYOBJ) {
-    nm_register_values(reinterpret_cast<VALUE*>(init), 1);
+    
+    if (dtype == nm::RUBYOBJ) {
+      nm_register_values(reinterpret_cast<VALUE*>(init), 1);
+    }
   }
 
   // capacity = h[:capacity] || 0
@@ -1098,10 +1098,11 @@ static VALUE nm_init_new_version(int argc, VALUE* argv, VALUE self) {
   }
 
   if (!NIL_P(initial_ary)) {
-    v = interpret_initial_value(initial_ary, dtype);
-
+    
     if (TYPE(initial_ary) == T_ARRAY) 	v_size = RARRAY_LEN(initial_ary);
     else                                v_size = 1;
+
+    v = interpret_initial_value(initial_ary, dtype);
 
     if (dtype == nm::RUBYOBJ) {
       nm_register_values(reinterpret_cast<VALUE*>(v), v_size);
@@ -1177,7 +1178,7 @@ static VALUE nm_init_new_version(int argc, VALUE* argv, VALUE self) {
     nm_unregister_values(reinterpret_cast<VALUE*>(v), v_size);
   }
 
-  if (dtype == nm::RUBYOBJ) {
+  if (stype != nm::DENSE_STORE && dtype == nm::RUBYOBJ) {
     nm_unregister_values(reinterpret_cast<VALUE*>(init), 1);
   }
 


### PR DESCRIPTION
Two more minor bugs.

I also tracked down the dense matrix valgrind issue, and it comes from not unregistering a variable when the ArgumentError is raised in the nmatrix spec "adequately requires information to access a single entry of a dense matrix".  There's no easy fix to this at the moment without adding some way to trap ruby exceptions in the C code.  (This also isn't a big deal, as all this is doing is passing an extra address to the marking function.)
