### PR TITLE
Changed list storage temp value registration.

### DIFF
--- a/ext/nmatrix/storage/list/list.cpp
+++ b/ext/nmatrix/storage/list/list.cpp
@@ -187,18 +187,20 @@ static void map_empty_stored_r(RecurseData& result, RecurseData& s, LIST* x, con
     }
     __nm_list_storage_unregister_temp_list_list(temp_vals, rec-1);
   } else {
-    std::list<VALUE> temp_vals;
+    std::list<VALUE*> temp_vals;
     while (curr) {
       VALUE val, s_val = rubyobj_from_cval(curr->val, s.dtype()).rval;
       if (rev) val = rb_yield_values(2, t_init, s_val);
       else     val = rb_yield_values(2, s_val, t_init);
 
       nm_register_value(val);
-      temp_vals.push_front(val);
 
       if (rb_funcall(val, rb_intern("!="), 1, result.init_obj()) == Qtrue) {
         xcurr = nm::list::insert_helper(x, xcurr, curr->key - offset, val);
+        temp_vals.push_front(reinterpret_cast<VALUE*>(xcurr->val));
+        nm_register_value(*reinterpret_cast<VALUE*>(xcurr->val));
       }
+      nm_unregister_value(val);
 
       curr = curr->next;
       if (curr && curr->key - offset >= x_shape) curr = NULL;
@@ -253,7 +255,7 @@ static void map_stored_r(RecurseData& result, RecurseData& left, LIST* x, const 
     }
     __nm_list_storage_unregister_temp_list_list(temp_vals, rec-1);
   } else {
-    std::list<VALUE> temp_vals;
+    std::list<VALUE*> temp_vals;
     while (lcurr) {
       size_t key;
       VALUE  val;
@@ -261,11 +263,12 @@ static void map_stored_r(RecurseData& result, RecurseData& left, LIST* x, const 
       val   = rb_yield_values(1, rubyobj_from_cval(lcurr->val, left.dtype()).rval);
       key   = lcurr->key - left.offset(rec);
       lcurr = lcurr->next;
-      nm_register_value(val);
-      temp_vals.push_front(val);
 
-      if (!rb_equal(val, result.init_obj()))
+      if (!rb_equal(val, result.init_obj())) {
         xcurr = nm::list::insert_helper(x, xcurr, key, val);
+        temp_vals.push_front(reinterpret_cast<VALUE*>(xcurr->val));
+        nm_register_value(*reinterpret_cast<VALUE*>(xcurr->val));
+      }
 
       if (lcurr && lcurr->key - left.offset(rec) >= result.ref_shape(rec)) lcurr = NULL;
     }
@@ -332,16 +335,16 @@ static void map_merged_stored_r(RecurseData& result, RecurseData& left, RecurseD
 
       if (!val->first) nm::list::del(val, 0); // empty list -- don't insert
       else {
-	nm_list_storage_register_list(val, rec-1);
-	temp_vals.push_front(val);
-	xcurr = nm::list::insert_helper(x, xcurr, key, val);
+       nm_list_storage_register_list(val, rec-1);
+       temp_vals.push_front(val);
+       xcurr = nm::list::insert_helper(x, xcurr, key, val);
       }
       if (rcurr && rcurr->key - right.offset(rec) >= result.ref_shape(rec)) rcurr = NULL;
       if (lcurr && lcurr->key - left.offset(rec) >= result.ref_shape(rec)) lcurr = NULL;
     }
     __nm_list_storage_unregister_temp_list_list(temp_vals, rec-1);
   } else {
-    std::list<VALUE> temp_vals;
+    std::list<VALUE*> temp_vals;
     while (lcurr || rcurr) {
       size_t key;
       VALUE  val;
@@ -360,11 +363,16 @@ static void map_merged_stored_r(RecurseData& result, RecurseData& left, RecurseD
         lcurr = lcurr->next;
         rcurr = rcurr->next;
       }
-      temp_vals.push_front(val);
+
       nm_register_value(val);
 
-      if (rb_funcall(val, rb_intern("!="), 1, result.init_obj()) == Qtrue)
+      if (rb_funcall(val, rb_intern("!="), 1, result.init_obj()) == Qtrue) {
         xcurr = nm::list::insert_helper(x, xcurr, key, val);
+        temp_vals.push_front(reinterpret_cast<VALUE*>(xcurr->val));
+        nm_register_value(*reinterpret_cast<VALUE*>(xcurr->val));
+      }
+
+      nm_unregister_value(val);
 
       if (rcurr && rcurr->key - right.offset(rec) >= result.ref_shape(rec)) rcurr = NULL;
       if (lcurr && lcurr->key - left.offset(rec) >= result.ref_shape(rec)) lcurr = NULL;
@@ -460,7 +468,7 @@ static bool slice_set(LIST_STORAGE* dest, LIST* l, size_t* coords, size_t* lengt
 
     size_t i    = 0;
     size_t key  = i + offsets[n] + coords[n];
-    std::list<VALUE> temp_vals;
+    std::list<VALUE*> temp_vals;
     while (i < lengths[n]) {
       // Make sure we have an element to work with
       if (v_offset >= v_size) v_offset %= v_size;
@@ -481,10 +489,10 @@ static bool slice_set(LIST_STORAGE* dest, LIST* l, size_t* coords, size_t* lengt
           }
         } else if (node->key > key) {
           D* nv = NM_ALLOC(D); *nv = v[v_offset++];
-	  if (dest->dtype == nm::RUBYOBJ) {
-	    nm_register_value(*reinterpret_cast<VALUE*>(nv));
-	    temp_vals.push_front(*reinterpret_cast<VALUE*>(nv));
-	  }
+          if (dest->dtype == nm::RUBYOBJ) {
+           nm_register_value(*reinterpret_cast<VALUE*>(nv));
+           temp_vals.push_front(reinterpret_cast<VALUE*>(nv));
+         }
           if (prev) node = insert_after(prev, key, nv);
           else      node = insert_first_node(l, key, nv, sizeof(D));
 
@@ -493,10 +501,10 @@ static bool slice_set(LIST_STORAGE* dest, LIST* l, size_t* coords, size_t* lengt
         }
       } else { // no node -- insert a new one
         D* nv = NM_ALLOC(D); *nv = v[v_offset++];
-	if (dest->dtype == nm::RUBYOBJ) {
-	  nm_register_value(*reinterpret_cast<VALUE*>(nv));
-	  temp_vals.push_front(*reinterpret_cast<VALUE*>(nv));
-	}
+        if (dest->dtype == nm::RUBYOBJ) {
+         nm_register_value(*reinterpret_cast<VALUE*>(nv));
+         temp_vals.push_front(reinterpret_cast<VALUE*>(nv));
+       }
         if (prev) node = insert_after(prev, key, nv);
         else      node = insert_first_node(l, key, nv, sizeof(D));
 
@@ -677,9 +685,9 @@ void nm_list_storage_mark(STORAGE* storage_base) {
   }
 }
 
-void __nm_list_storage_unregister_temp_value_list(std::list<VALUE>& temp_vals) {
-  for (std::list<VALUE>::iterator it = temp_vals.begin(); it != temp_vals.end(); ++it) {
-    nm_unregister_value(*it);
+void __nm_list_storage_unregister_temp_value_list(std::list<VALUE*>& temp_vals) {
+  for (std::list<VALUE*>::iterator it = temp_vals.begin(); it != temp_vals.end(); ++it) {
+    nm_unregister_value(**it);
   }
 }
 
@@ -1043,7 +1051,6 @@ VALUE nm_list_map_merged_stored(VALUE left, VALUE right, VALUE init) {
   NMATRIX* result = nm_create(nm::LIST_STORE, nm_list_storage_create(nm::RUBYOBJ, sdata.copy_alloc_shape(), s->dim, init_val));
   LIST_STORAGE* r = reinterpret_cast<LIST_STORAGE*>(result->storage);
   nm::list_storage::RecurseData rdata(r, init);
-  nm_register_nmatrix(result);
   map_merged_stored_r(rdata, sdata, tdata, rdata.top_level_list(), sdata.top_level_list(), tdata.top_level_list(), sdata.dim() - 1);
 
   delete &tdata;
@@ -1052,7 +1059,8 @@ VALUE nm_list_map_merged_stored(VALUE left, VALUE right, VALUE init) {
 
   VALUE to_return = Data_Wrap_Struct(CLASS_OF(left), nm_mark, nm_delete, result);
 
-  nm_unregister_nmatrix(result);
+  nm_unregister_value(*reinterpret_cast<VALUE*>(init_val));
+
   nm_unregister_value(init);
   nm_unregister_value(right);
   nm_unregister_value(left);
@@ -1071,7 +1079,7 @@ static LIST* slice_copy(const LIST_STORAGE* src, LIST* src_rows, size_t* coords,
   
   LIST* dst_rows = nm::list::create();
   NODE* src_node = src_rows->first;
-  std::list<VALUE> temp_vals;
+  std::list<VALUE*> temp_vals;
   std::list<LIST*> temp_lists;
   while (src_node) {
     key = src_node->key - (src->offset[n] + coords[n]);
@@ -1093,7 +1101,7 @@ static LIST* slice_copy(const LIST_STORAGE* src, LIST* src_rows, size_t* coords,
       } else { // matches src->dim - n > 1
 	if (src->dtype == nm::RUBYOBJ) {
 	  nm_register_value(*reinterpret_cast<VALUE*>(src_node->val));
-	  temp_vals.push_front(*reinterpret_cast<VALUE*>(src_node->val));
+	  temp_vals.push_front(reinterpret_cast<VALUE*>(src_node->val));
 	}
 	nm::list::insert_copy(dst_rows, false, key, src_node->val, DTYPE_SIZES[src->dtype]);
       }
@@ -1212,7 +1220,7 @@ static void slice_set_single(LIST_STORAGE* dest, LIST* l, void* val, size_t* coo
     }
     __nm_list_storage_unregister_temp_list_list(temp_nodes, dest->dim - n - 2);
   } else {
-    std::list<VALUE> temp_vals;
+    std::list<VALUE*> temp_vals;
     for (size_t i = 0; i < lengths[n]; ++i) {
 
       size_t key = i + dest->offset[n] + coords[n];
@@ -1223,8 +1231,8 @@ static void slice_set_single(LIST_STORAGE* dest, LIST* l, void* val, size_t* coo
         node = nm::list::replace_insert_after(node, key, val, true, DTYPE_SIZES[dest->dtype]);
       }
       if (dest->dtype == nm::RUBYOBJ) {
-	temp_vals.push_front(*reinterpret_cast<VALUE*>(node->val));
-	nm_register_value(*reinterpret_cast<VALUE*>(node->val));
+        temp_vals.push_front(reinterpret_cast<VALUE*>(node->val));
+        nm_register_value(*reinterpret_cast<VALUE*>(node->val));
       }
     }
     __nm_list_storage_unregister_temp_value_list(temp_vals);

--- a/ext/nmatrix/storage/list/list.h
+++ b/ext/nmatrix/storage/list/list.h
@@ -73,7 +73,7 @@ extern "C" {
   void					nm_list_storage_delete(STORAGE* s);
   void					nm_list_storage_delete_ref(STORAGE* s);
   void					nm_list_storage_mark(STORAGE*);
-  void          __nm_list_storage_unregister_temp_value_list(std::list<VALUE>& temp_vals);
+  void          __nm_list_storage_unregister_temp_value_list(std::list<VALUE*>& temp_vals);
   void		__nm_list_storage_unregister_temp_list_list(std::list<LIST*>& temp_vals, size_t recursions);
   void          nm_list_storage_register(const STORAGE* s);
   void          nm_list_storage_unregister(const STORAGE* s);

--- a/ext/nmatrix/util/sl_list.cpp
+++ b/ext/nmatrix/util/sl_list.cpp
@@ -193,7 +193,6 @@ NODE* insert(LIST* list, bool replace, size_t key, void* val) {
       nm_list_storage_completely_unregister_node(ins);
       NM_FREE(ins->val);
       ins->val = val;
-      nm_list_storage_register_node(ins);
     } else {
       NM_FREE(val);
     }


### PR DESCRIPTION
Previously, temporary values registered during a recursion were added to a
std::list as VALUE and not VALUE*.  While this would keep the GC from
collecting them, this could cause problems because the address registered was
on the stack and might go out of scope (and then cause invalid read errors.

This fixes the only valgrind problem I could find (which I was able to get by going back to p195 again).  Not sure if it will fix everything you're seeing, but it was a pretty major problem, so it's possible this was the cause of your numerous valgrind errors.
